### PR TITLE
Remove @ensured_* variables.

### DIFF
--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -75,11 +75,8 @@ require 'tempfile'
     end
 
     def ensure_roundsman_working_dir
-      unless @ensured_roundsman_working_dir
-        run "mkdir -p #{fetch(:roundsman_working_dir)}"
-        sudo "chown -R #{fetch(:roundsman_user)} #{fetch(:roundsman_working_dir)}"
-        @ensured_roundsman_working_dir = true
-      end
+      run "mkdir -p #{fetch(:roundsman_working_dir)}"
+      sudo "chown -R #{fetch(:roundsman_user)} #{fetch(:roundsman_working_dir)}"
     end
 
 
@@ -138,11 +135,8 @@ require 'tempfile'
       end
 
       def ensure_supported_distro
-        unless @ensured_supported_distro
-          logger.info "Using Linux distribution #{distribution}"
-          abort "This distribution is not (yet) supported." unless distribution.include?("Ubuntu")
-          @ensured_supported_distro = true
-        end
+        logger.info "Using Linux distribution #{distribution}"
+        abort "This distribution is not (yet) supported." unless distribution.include?("Ubuntu")
       end
 
       def install_ruby?


### PR DESCRIPTION
When running different run lists per role, @ensured_\* variables are not refreshed, and for example, roundsman thinks it already created /tmp/roundsman, but that's not the case, since we're contacting a different host now. Since the ensure operations are quick and idempotent, no need to go extra mile just to skip them.
