### PR TITLE
skip chef/ruby checks

### DIFF
--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -8,7 +8,7 @@ require 'tempfile'
     def run_list(*recipes)
       if recipes.any?
         set :run_list, recipes
-        install_ruby
+        install_ruby if fetch(:run_roundsman_checks, true) && install_ruby?
         run_chef
       else
         Array(fetch(:run_list))
@@ -48,6 +48,7 @@ require 'tempfile'
     set_default(:roundsman_user) { fetch(:user) { capture('whoami').strip } }
     set_default :debug_chef, false
     set_default :package_manager, 'apt-get'
+    set_default :run_roundsman_checks, true
 
     desc "Lists configuration"
     task :configuration do
@@ -183,7 +184,7 @@ require 'tempfile'
 
       desc "Generates the config and copies over the cookbooks to the server"
       task :prepare_chef, :except => { :no_release => true } do
-        install if install_chef?
+        install if fetch(:run_roundsman_checks, true) && install_chef?
         ensure_cookbooks_exists
         generate_config
         generate_attributes


### PR DESCRIPTION
Hi,

Great project.

wanted to reduce a little noise, so added a configuration variable to skip the ruby/chef check.

Also noticed that the ruby check and the chef checks were setup differently.
install_ruby made the checks internally, while chef.install only happened when the external chef check didn't pass.

I made a stab for the external version, but please advise if you prefer the other way. I can change easily.
I liked the external because it reduced the amount of information going across the screen. But am unsure about your use case with the no_release flag

Thanks,
Keenan
