### PR TITLE
Create cache/ directory under roundsman_working_directory

### DIFF
--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -77,6 +77,7 @@ require 'tempfile'
     def ensure_roundsman_working_dir
       unless @ensured_roundsman_working_dir
         run "mkdir -p #{fetch(:roundsman_working_dir)}"
+        run "mkdir -p #{fetch(:roundsman_working_dir)}/cache"
         sudo "chown -R #{fetch(:roundsman_user)} #{fetch(:roundsman_working_dir)}"
         @ensured_roundsman_working_dir = true
       end


### PR DESCRIPTION
Some cookbooks uses cache directory for downloading archives.
but roundsman does not create it on initialize,
then chef got failures on first execution.
