### PR TITLE
Fix false values has been removed on generating solo.json

### DIFF
--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -256,7 +256,7 @@ require 'tempfile'
           if real_value.is_a?(Hash)
             real_value = remove_procs_from_hash(real_value)
           end
-          if real_value && !real_value.class.to_s.include?("Capistrano") # skip capistrano tasks
+          if real_value != nil && !real_value.class.to_s.include?("Capistrano") # skip capistrano tasks
             new_hash[key] = real_value
           end
         end


### PR DESCRIPTION
Some cookbook uses boolean value for customize its behavior.
but remove_procs_from_hash() removes all false values.
