### PR TITLE
Per-server conf and add role + data bags paths to solo.rb file

### DIFF
--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -254,15 +254,6 @@ require 'tempfile'
 
           put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => current_server.host
         end
-
-        # if variables.has_key?(:per_server_conf)
-        #   per_server_conf.each do |servers, conf|
-        #     server_conf = attrs.merge(conf)
-        #     put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => servers
-        #   end
-        # else
-        #   put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
-        # end
       end
 
       # Recursively removes procs from hashes. Procs can exist because you specified them like this:

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -174,6 +174,7 @@ require 'tempfile'
       set_default :cookbooks_directory, ["config/cookbooks"]
       set_default :copyfile_disable, false
       set_default :filter_sensitive_settings, [ /password/, /filter_sensitive_settings/ ]
+      set_default :remove_settings_from_chef, [ ]
 
       task :default, :except => { :no_release => true } do
         ensure_cookbooks_exists
@@ -260,9 +261,11 @@ require 'tempfile'
       #
       #     set(:root_password) { Capistrano::CLI.password_prompt("Root password: ") }
       def remove_procs_from_hash(hash)
+        filter_fields = Array(fetch(:filter_sensitive_settings)) + Array(fetch(:remove_settings_from_chef))
+
         new_hash = {}
         hash.each do |key, value|
-          next if fetch(:filter_sensitive_settings).find { |regex| regex === key }
+          next if filter_fields.find { |matcher| matcher === key }
           real_value = if value.respond_to?(:call)
             begin
               value.call

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -244,14 +244,9 @@ require 'tempfile'
       end
 
       def generate_attributes
-        attrs = remove_procs_from_hash variables.dup
-
-        remove_attrs = fetch(:roundsman_skip_attrs) if variables.has_key?(:roundsman_skip_attrs)
-
         find_servers_for_task(current_task).each do |current_server|
-          server_conf = attrs.merge(current_server.options)
-
-          server_conf.delete(*remove_attrs) if remove_attrs
+          merged_options  = variables.merge(current_server.options)
+          server_conf     = remove_procs_from_hash(merged_options)
 
           put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => current_server.host
         end

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -264,7 +264,7 @@ require 'tempfile'
       def remove_procs_from_hash(hash)
         new_hash = {}
         hash.each do |key, value|
-          next if fetch(:filter_sensitive_settings).find { |regex| regex.match(key) }
+          next if fetch(:filter_sensitive_settings).find { |regex| regex === key }
           real_value = if value.respond_to?(:call)
             begin
               value.call

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -248,7 +248,14 @@ require 'tempfile'
         remove_attrs = fetch(:roundsman_skip_attrs)
         attrs.delete(*remove_attrs) if remove_attrs
 
-        put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
+        if variables.has_key?(:per_server_conf)
+          per_server_conf.each do |servers, conf|
+            server_conf = attrs.merge(conf)
+            put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => servers
+          end
+        else
+          put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
+        end
       end
 
       # Recursively removes procs from hashes. Procs can exist because you specified them like this:

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -244,6 +244,10 @@ require 'tempfile'
 
       def generate_attributes
         attrs = remove_procs_from_hash variables.dup
+
+        remove_attrs = fetch(:roundsman_skip_attrs)
+        attrs.delete(*remove_attrs) if remove_attrs
+
         put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
       end
 

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -245,7 +245,7 @@ require 'tempfile'
       def generate_attributes
         attrs = remove_procs_from_hash variables.dup
 
-        remove_attrs = fetch(:roundsman_skip_attrs)
+        remove_attrs = fetch(:roundsman_skip_attrs) if variables.has_key?(:roundsman_skip_attrs)
 
         find_servers_for_task(current_task).each do |current_server|
           server_conf = attrs.merge(current_server.options)

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -246,16 +246,23 @@ require 'tempfile'
         attrs = remove_procs_from_hash variables.dup
 
         remove_attrs = fetch(:roundsman_skip_attrs)
-        attrs.delete(*remove_attrs) if remove_attrs
 
-        if variables.has_key?(:per_server_conf)
-          per_server_conf.each do |servers, conf|
-            server_conf = attrs.merge(conf)
-            put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => servers
-          end
-        else
-          put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
+        find_servers_for_task(current_task).each do |current_server|
+          server_conf = attrs.merge(current_server.options)
+
+          server_conf.delete(*remove_attrs) if remove_attrs
+
+          put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => current_server.host
         end
+
+        # if variables.has_key?(:per_server_conf)
+        #   per_server_conf.each do |servers, conf|
+        #     server_conf = attrs.merge(conf)
+        #     put server_conf.to_json, roundsman_working_dir("solo.json"), :via => :scp, :hosts => servers
+        #   end
+        # else
+        #   put attrs.to_json, roundsman_working_dir("solo.json"), :via => :scp
+        # end
       end
 
       # Recursively removes procs from hashes. Procs can exist because you specified them like this:

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -209,7 +209,15 @@ require 'tempfile'
       end
 
       def cookbooks_paths
-        Array(fetch(:cookbooks_directory)).select { |path| File.exist?(path) }
+        Array(fetch(:cookbook_path)).select { |path| File.exist?(path) }
+      end
+
+      def roles_path
+        fetch(:role_path)
+      end
+
+      def data_bags_path
+        fetch(:data_bag_path)
       end
 
       def install_chef?
@@ -220,11 +228,17 @@ require 'tempfile'
 
       def generate_config
         cookbook_string = cookbooks_paths.map { |c| "File.join(root, #{c.to_s.inspect})" }.join(', ')
+        role_string = "File.join(root, #{roles_path.to_s.inspect})" if roles_path
+        data_bag_string = "File.join(root, #{data_bags_path.to_s.inspect})" if data_bags_path
         solo_rb = <<-RUBY
           root = File.expand_path(File.dirname(__FILE__))
           file_cache_path File.join(root, "cache")
           cookbook_path [ #{cookbook_string} ]
         RUBY
+
+        solo_rb << "role_path #{role_string}\n" if role_string
+        solo_rb << "data_bag_path #{data_bag_string}\n" if data_bag_string
+
         put solo_rb, roundsman_working_dir("solo.rb"), :via => :scp
       end
 

--- a/lib/roundsman/capistrano.rb
+++ b/lib/roundsman/capistrano.rb
@@ -8,7 +8,7 @@ require 'tempfile'
     def run_list(*recipes)
       if recipes.any?
         set :run_list, recipes
-        install_ruby if fetch(:run_roundsman_checks, true) && install_ruby?
+        install_ruby
         run_chef
       else
         Array(fetch(:run_list))
@@ -48,11 +48,10 @@ require 'tempfile'
     set_default(:roundsman_user) { fetch(:user) { capture('whoami').strip } }
     set_default :debug_chef, false
     set_default :package_manager, 'apt-get'
-    set_default :run_roundsman_checks, true
 
     desc "Lists configuration"
     task :configuration do
-      @_defaults.sort_by {|sym| sym.to_s}.each do |name|
+      @_defaults.sort.each do |name|
         display_name = ":#{name},".ljust(30)
         if variables[name].is_a?(Proc)
           value = "<block>"
@@ -76,29 +75,10 @@ require 'tempfile'
     end
 
     def ensure_roundsman_working_dir
-      run "mkdir -p #{fetch(:roundsman_working_dir)}"
-      run "mkdir -p #{fetch(:roundsman_working_dir)}/cache"
-      sudo "chown -R #{fetch(:roundsman_user)} #{fetch(:roundsman_working_dir)}"
-    end
-
-    def install_ruby?
-      installed_version = capture("ruby --version || true").strip
-      if installed_version.include?("not found")
-        logger.info "No version of Ruby could be found."
-        return true
-      end
-      required_version = fetch(:ruby_version).gsub("-", "")
-      if fetch(:care_about_ruby_version)
-        if installed_version.include?(required_version)
-          logger.info "Ruby #{installed_version} matches the required version: #{required_version}."
-          return false
-        else
-          logger.info "Ruby version mismatch. Installed version: #{installed_version}, required is #{required_version}"
-          return true
-        end
-      else
-        logger.info "Already installed Ruby #{installed_version}, not #{required_version}. Set :care_about_ruby_version if you want to fix this."
-        return false
+      unless @ensured_roundsman_working_dir
+        run "mkdir -p #{fetch(:roundsman_working_dir)}/cache"
+        sudo "chown -R #{fetch(:roundsman_user)} #{fetch(:roundsman_working_dir)}"
+        @ensured_roundsman_working_dir = true
       end
     end
 
@@ -158,19 +138,41 @@ require 'tempfile'
       end
 
       def ensure_supported_distro
-        logger.info "Using Linux distribution #{distribution}"
-        abort "This distribution is not (yet) supported." unless distribution.include?("Ubuntu")
+        unless @ensured_supported_distro
+          logger.info "Using Linux distribution #{distribution}"
+          abort "This distribution is not (yet) supported." unless distribution.include?("Ubuntu")
+          @ensured_supported_distro = true
+        end
+      end
+
+      def install_ruby?
+        installed_version = capture("ruby --version || true").strip
+        if installed_version.include?("not found")
+          logger.info "No version of Ruby could be found."
+          return true
+        end
+        required_version = fetch(:ruby_version).gsub("-", "")
+        if installed_version.include?(required_version)
+          if fetch(:care_about_ruby_version)
+            logger.info "Ruby #{installed_version} matches the required version: #{required_version}."
+            return false
+          else
+            logger.info "Already installed Ruby #{installed_version}, not #{required_version}. Set :care_about_ruby_version if you want to fix this."
+            return false
+          end
+        else
+          logger.info "Ruby version mismatch. Installed version: #{installed_version}, required is #{required_version}"
+          return true
+        end
       end
 
     end
 
     namespace :chef do
 
-      set_default :chef_version, "~> 10.18.2"
+      set_default :chef_version, "~> 0.10.8"
       set_default :cookbooks_directory, ["config/cookbooks"]
-      set_default :databags_directory, "config/data_bags"
       set_default :copyfile_disable, false
-      set_default :verbose_logging, true
       set_default :filter_sensitive_settings, [ /password/, /filter_sensitive_settings/ ]
 
       task :default, :except => { :no_release => true } do
@@ -181,7 +183,7 @@ require 'tempfile'
 
       desc "Generates the config and copies over the cookbooks to the server"
       task :prepare_chef, :except => { :no_release => true } do
-        install if fetch(:run_roundsman_checks, true) && install_chef?
+        install if install_chef?
         ensure_cookbooks_exists
         generate_config
         generate_attributes
@@ -190,27 +192,15 @@ require 'tempfile'
 
       desc "Installs chef"
       task :install, :except => { :no_release => true } do
-        if self[:rvm_type] == :user
-          run "gem uninstall -xaI chef || true"
-          run "gem install chef -v #{fetch(:chef_version).inspect} --quiet --no-ri --no-rdoc"
-          run "gem install ruby-shadow --quiet --no-ri --no-rdoc"
-        else
-          sudo "gem uninstall -xaI chef || true"
-          sudo "gem install chef -v #{fetch(:chef_version).inspect} --quiet --no-ri --no-rdoc"
-          sudo "gem install ruby-shadow --quiet --no-ri --no-rdoc"
-        end
+        sudo "gem uninstall -xaI chef || true"
+        sudo "gem install chef -v #{fetch(:chef_version).inspect} --quiet --no-ri --no-rdoc"
+        sudo "gem install ruby-shadow --quiet --no-ri --no-rdoc"
       end
 
       desc "Runs the existing chef configuration"
       task :chef_solo, :except => { :no_release => true } do
         logger.info "Now running #{fetch(:run_list).join(', ')}"
-        old_sudo = self[:sudo]
-        if self[:rvm_type] == :user
-          self[:sudo] = "rvmsudo_secure_path=1 #{File.join(rvm_bin_path, "rvmsudo")}"
-        end
-
         sudo "chef-solo -c #{roundsman_working_dir("solo.rb")} -j #{roundsman_working_dir("solo.json")}#{' -l debug' if fetch(:debug_chef)}"
-        self[:sudo] = old_sudo
       end
 
       def ensure_cookbooks_exists
@@ -220,11 +210,6 @@ require 'tempfile'
 
       def cookbooks_paths
         Array(fetch(:cookbooks_directory)).select { |path| File.exist?(path) }
-      end
-
-      def databags_path
-        path = fetch(:databags_directory)
-        File.exist?(path) ? path : nil
       end
 
       def install_chef?
@@ -239,8 +224,6 @@ require 'tempfile'
           root = File.expand_path(File.dirname(__FILE__))
           file_cache_path File.join(root, "cache")
           cookbook_path [ #{cookbook_string} ]
-          verbose_logging #{fetch(:verbose_logging)}
-          data_bag_path File.join(root, #{fetch(:databags_directory).to_s.inspect})
         RUBY
         put solo_rb, roundsman_working_dir("solo.rb"), :via => :scp
       end
@@ -256,7 +239,7 @@ require 'tempfile'
       def remove_procs_from_hash(hash)
         new_hash = {}
         hash.each do |key, value|
-          next if fetch(:filter_sensitive_settings).find { |regex| regex.match(key.to_s) }
+          next if fetch(:filter_sensitive_settings).find { |regex| regex.match(key) }
           real_value = if value.respond_to?(:call)
             begin
               value.call
@@ -271,7 +254,7 @@ require 'tempfile'
           if real_value.is_a?(Hash)
             real_value = remove_procs_from_hash(real_value)
           end
-          if real_value != nil && !real_value.class.to_s.include?("Capistrano") # skip capistrano tasks
+          if real_value && !real_value.class.to_s.include?("Capistrano") # skip capistrano tasks
             new_hash[key] = real_value
           end
         end
@@ -283,7 +266,7 @@ require 'tempfile'
         begin
           tar_file.close
           env_vars = fetch(:copyfile_disable) && RUBY_PLATFORM.downcase.include?('darwin') ? "COPYFILE_DISABLE=true" : ""
-          system "#{env_vars} tar -cjf #{tar_file.path} #{cookbooks_paths.join(' ')} #{databags_path.to_s}"
+          system "#{env_vars} tar -cjf #{tar_file.path} #{cookbooks_paths.join(' ')}"
           upload tar_file.path, roundsman_working_dir("cookbooks.tar"), :via => :scp
           run "cd #{roundsman_working_dir} && tar -xjf cookbooks.tar"
         ensure


### PR DESCRIPTION
Let me know if you care to use these changes... Or what you'd like to see before merging it in.

This includes a few changes:
- Configurations are now uploaded per-server; ie, I can now do:

``` ruby
  role :web, "customer1-server.foo.com", {subdomain: "customer1", db_host: "cust1db", db_user: "some-user", ...}
  role :web, "customer2-server.foo.com", {subdomain: "customer2", db_host: "cust2db", db_user: "other-user", ...}

```
- The data bags / roles path can now be set in the Capfile / deploy.rb.  I had issues using a role file / data bags... I'd much rather not set the run_list in Roundsman.  I'd like to keep it all in a single file that belongs to chef, and have Roundsman deliver enough information for it to make a sound decision.
- `remove_procs_from_hash` now uses Threequals (`===`) instead of .match, as I had a really bizarre issue with some Cap variables that really wasn't worth debugging.  Threequals will behave the same as .match.  For arguments that .match would normally throw an except over, it will simply return false.
